### PR TITLE
fix kex.sh

### DIFF
--- a/kex.sh
+++ b/kex.sh
@@ -6,4 +6,4 @@ java \
 	-Djava.security.manager \
 	-Djava.security.policy==kex.policy \
 	-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener \
-	-jar kex-runner/target/kex-runner-*-jar-with-dependencies.jar $*
+	-jar kex-runner/target/kex-runner-*-jar-with-dependencies.jar "$@"


### PR DESCRIPTION
Correctly pass arguments from script to kex-runner: include quotes and spaces.

Before 90426547c378f320a566593218acad22530444cf:
* kex.sh
`-cp "/home/IntelliJ IDEA/project/target/classes:/home/IntelliJ IDEA/project/module/target/classes" ...`
* kex-runner.jar
`-cp /home/IntelliJ IDEA/project/target/classes:/home/IntelliJ IDEA/project/module/target/classes ...`

After 90426547c378f320a566593218acad22530444cf:
* kex.sh
`-cp "/home/IntelliJ IDEA/project/target/classes:/home/IntelliJ IDEA/project/module/target/classes" ...`
* kex-runner.jar
`-cp "/home/IntelliJ IDEA/project/target/classes:/home/IntelliJ IDEA/project/module/target/classes" ...`