### PR TITLE
Use `:=` instead of `=` for store predicates

### DIFF
--- a/kex-core/src/main/kotlin/org/vorpal/research/kex/state/predicate/ArrayStorePredicate.kt
+++ b/kex-core/src/main/kotlin/org/vorpal/research/kex/state/predicate/ArrayStorePredicate.kt
@@ -25,7 +25,7 @@ class ArrayStorePredicate(
     val componentType: KexType
         get() = (arrayRef.type as? KexReference)?.reference ?: unreachable { log.error("Non-array type of array ref") }
 
-    override fun print() = "*($arrayRef) = $value"
+    override fun print() = "*($arrayRef) := $value"
 
     override fun <T : Transformer<T>> accept(t: Transformer<T>): Predicate {
         val ref = t.transform(arrayRef)

--- a/kex-core/src/main/kotlin/org/vorpal/research/kex/state/predicate/FieldStorePredicate.kt
+++ b/kex-core/src/main/kotlin/org/vorpal/research/kex/state/predicate/FieldStorePredicate.kt
@@ -17,7 +17,7 @@ class FieldStorePredicate(
         @Required @Contextual override val location: Location = Location()) : Predicate() {
     override val operands by lazy { listOf(this.field, this.value) }
 
-    override fun print() = "*($field) = $value"
+    override fun print() = "*($field) := $value"
 
     override fun <T : Transformer<T>> accept(t: Transformer<T>): Predicate {
         val tField = t.transform(field)


### PR DESCRIPTION
`*(v.left) := u` is for `FieldStorePredicate` and `*(v.left) = u` is for `EqualityPredicate` of `FieldLoadTerm` and `u`