### PR TITLE
Kotlin Nullability support

### DIFF
--- a/kex-core/pom.xml
+++ b/kex-core/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>easy-random-core</artifactId>
             <version>${easy-random.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-metadata-jvm</artifactId>
+            <version>${kotlinx-metadata.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kex-core/src/main/kotlin/org/vorpal/research/kex/util/kmetadata.kt
+++ b/kex-core/src/main/kotlin/org/vorpal/research/kex/util/kmetadata.kt
@@ -1,0 +1,60 @@
+package org.vorpal.research.kex.util
+
+import kotlinx.metadata.*
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import org.vorpal.research.kex.ktype.KexArray
+import org.vorpal.research.kex.ktype.KexPointer
+import org.vorpal.research.kex.ktype.KexType
+import org.vorpal.research.kfg.ir.Method
+import kotlin.reflect.KType
+
+
+fun Class<*>.getKotlinMetadata(): KotlinClassMetadata {
+    val annotation = this.getAnnotation(Metadata::class.java)
+    return KotlinClassMetadata.readStrict(annotation)
+}
+
+private fun trimClassName(name: String) = buildString {
+    val actualName = name.split(" ").last()
+    val filtered = actualName.dropWhile { it == '[' }.removeSuffix(";")
+    append(actualName.takeWhile { it == '[' })
+    append(filtered.dropWhile { it == 'L' })
+}
+
+fun KexType.isElementNullable(kmType: KmType) = when (this) {
+    is KexArray -> when {
+        kmType.arguments.isEmpty() -> false
+        else -> kmType.arguments.first().type?.isNullable ?: false
+    }
+
+    else -> false
+}
+
+fun KexType.isNonNullable(kmType: KmType) = when (this) {
+    is KexPointer -> !kmType.isNullable
+    else -> false
+}
+
+val KmType.trimmedName: String
+    get() {
+        return when (val classifier = this.classifier) {
+            is KmClassifier.Class -> trimClassName(classifier.name)
+            is KmClassifier.TypeAlias -> trimClassName(classifier.name)
+            is KmClassifier.TypeParameter -> TODO("What should we do?")
+        }
+    }
+
+infix fun KmFunction.eq(method: Method): Boolean {
+    val parameters = this.valueParameters
+    val name = this.name
+    return name == method.name && parameters.zip(method.argTypes).fold(true) { acc, (kmType, methodType) ->
+        acc && methodType.trimmedName == kmType.type.trimmedName
+    }
+}
+
+fun KmClass.find(method: Method) = functions.find { it eq method }
+
+fun KmClass.getKFunction(method: Method): KmFunction? {
+    this.supertypes
+    return this.find(method) // TODO: find on supertypes is not available due to this.supertypes has a List<KmType> type
+}

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/concolic/InstructionConcolicChecker.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/concolic/InstructionConcolicChecker.kt
@@ -76,6 +76,14 @@ class InstructionConcolicChecker(
 
     private val compilerHelper = CompilerHelper(ctx)
 
+    private val constructedArguments: MutableList<Parameters<Descriptor>> = mutableListOf()
+
+    private fun collectArguments(params: Parameters<Descriptor>) {
+        if (!kexConfig.getBooleanValue("test", "collectArgumentFromTraces", false))
+            return
+        constructedArguments.add(params)
+    }
+
     companion object {
 
         private fun buildSelectorManager(
@@ -92,7 +100,7 @@ class InstructionConcolicChecker(
 
         @ExperimentalTime
         @DelicateCoroutinesApi
-        fun run(context: ExecutionContext, targets: Set<Method>) {
+        fun run(context: ExecutionContext, targets: Set<Method>): Map<Method, List<Parameters<Descriptor>>> { // FIXME
             val executors = kexConfig.getIntValue("concolic", "numberOfExecutors", 8)
             val timeLimit = kexConfig.getIntValue("concolic", "timeLimit", 100)
             val searchStrategy = kexConfig.getStringValue("concolic", "searchStrategy", "bfs")
@@ -102,20 +110,24 @@ class InstructionConcolicChecker(
 
             val selectorManager = buildSelectorManager(context, targets, searchStrategy)
             val testNameGenerator = TestNameGeneratorImpl()
+            val collectedArguments = mutableMapOf<Method, List<Parameters<Descriptor>>>()
 
             runBlocking(coroutineContext) {
                 withTimeoutOrNull(timeLimit.seconds) {
                     targets.map {
                         async {
-                            InstructionConcolicChecker(
+                            val instructionConcolicChecker = InstructionConcolicChecker(
                                 context,
                                 selectorManager.createPathSelectorFor(it),
                                 testNameGenerator
-                            ).start(it)
+                            )
+                            instructionConcolicChecker.start(it)
+                            collectedArguments[it] = instructionConcolicChecker.constructedArguments
                         }
                     }.awaitAll()
                 }
             }
+            return collectedArguments
         }
     }
 
@@ -143,8 +155,10 @@ class InstructionConcolicChecker(
 
     private suspend fun collectTraceFromAny(method: Method, parameters: Parameters<Any?>): ExecutionResult? =
         collectTrace(method, parameters.asDescriptors)
+            .also { collectArguments(parameters.asDescriptors) }
 
     private suspend fun collectTrace(method: Method, parameters: Parameters<Descriptor>): ExecutionResult? = tryOrNull {
+        collectArguments(parameters)
         val generator = UnsafeGenerator(ctx, method, testNameGenerator.generateName(method, parameters))
         generator.generate(parameters)
         val testFile = generator.emit()

--- a/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/KotlinNullabilityTest.kt
+++ b/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/KotlinNullabilityTest.kt
@@ -1,0 +1,266 @@
+package org.vorpal.research.kex.concolic
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import org.junit.Test
+import org.vorpal.research.kex.KexRunnerTest
+import org.vorpal.research.kex.asm.analysis.concolic.InstructionConcolicChecker
+import org.vorpal.research.kex.asm.manager.ClassInstantiationDetector
+import org.vorpal.research.kex.config.RuntimeConfig
+import org.vorpal.research.kex.descriptor.ArrayDescriptor
+import org.vorpal.research.kex.descriptor.ConstantDescriptor
+import org.vorpal.research.kex.descriptor.Descriptor
+import org.vorpal.research.kex.descriptor.ObjectDescriptor
+import org.vorpal.research.kex.parameters.Parameters
+import org.vorpal.research.kex.trace.runner.ExecutorMasterController
+import org.vorpal.research.kfg.Package
+import org.vorpal.research.kfg.ir.Class
+import org.vorpal.research.kfg.ir.Method
+import org.vorpal.research.kfg.visitor.executePackagePipeline
+import org.vorpal.research.kthelper.logging.log
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+@ExperimentalSerializationApi
+@InternalSerializationApi
+@DelicateCoroutinesApi
+class KotlinNullabilityTest : KexRunnerTest("kotlin-nullability") {
+    private val prefix = "org/vorpal/research/kex/test/concolic/kotlinNullability/"
+
+    init {
+        RuntimeConfig.setValue("test", "collectArgumentFromTraces", true)
+        RuntimeConfig.setValue("kex", "useReflectionInfo", true)
+    }
+
+    private fun runAndCollectArguments(klass: Class): Map<Method, List<Parameters<Descriptor>>> {
+        val collectedArguments = mutableMapOf<Method, List<Parameters<Descriptor>>>()
+        repeat(N_RUNS) {
+            ExecutorMasterController.use {
+                it.start(analysisContext)
+                executePackagePipeline(analysisContext.cm, Package.defaultPackage) {
+                    +ClassInstantiationDetector(analysisContext)
+                }
+                for (method in klass.allMethods.sortedBy { method -> method.prototype }) {
+                    val collectedFromRun = InstructionConcolicChecker.run(analysisContext, setOf(method))
+                    collectedArguments.putAll(collectedFromRun)
+                }
+                log.debug("collected arguments: {}", collectedArguments)
+            }
+        }
+        return collectedArguments.filterKeys { !it.isConstructor }
+    }
+
+    @Test
+    fun nonNullablePrimitives() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithoutNullableTypesTest"])
+        assertTrue {
+            collectedArguments
+                .filter { (method) -> method.name == "withoutNullableTypes" }
+                .values
+                .first()
+                .all { it.arguments.all { it !is ConstantDescriptor.Null } }
+        }
+    }
+
+    @Test
+    fun nonNullableArraysWithNonNullableElements() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithArrayWithoutNullsTest"])
+        assertTrue {
+            collectedArguments
+                .filter { (method) -> method.name == "withArrayWithoutNulls" }
+                .values
+                .first()
+                .all {
+                    it
+                        .arguments
+                        .all { it is ArrayDescriptor && it.elements.values.all { it !is ConstantDescriptor.Null } }
+                }
+        }
+    }
+
+    @Test
+    fun nonNullableArraysWithNullableElements() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithArrayWithNullsTest"])
+        assertTrue {
+            val args = collectedArguments
+                .filter { (method) -> method.name == "withArrayWithNulls" }
+                .values
+                .first()
+            if (!args.all { it.arguments.all { it is ArrayDescriptor } })
+                return@assertTrue false
+            val filtered = args.map { it.arguments.filterIsInstance<ArrayDescriptor>().first() }
+            filtered.any { it.elements.values.all { it is ConstantDescriptor.Null } } &&
+                    filtered.any { it.elements.values.any { it !is ConstantDescriptor.Null } }
+        }
+    }
+
+    @Test
+    fun nullableArrayWithNonNullableElements() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithNullableArrayTest"])
+        assertTrue {
+            val args = collectedArguments
+                .filter { (method) -> method.name == "withNullableArray" }
+                .values
+                .first()
+            args.any { it.arguments.all { it is ConstantDescriptor.Null } }
+                    && args.any { it.arguments.all { it is ArrayDescriptor && it.elements.values.all { it !is ConstantDescriptor.Null } } }
+        }
+    }
+
+    @Test
+    fun nullableArrayWithNullableElements() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithNullableArrayWithNullableTypes"])
+        assertTrue {
+            val args = collectedArguments
+                .filter { (method) -> method.name == "withNullableArrayWithNullableTypes" }
+                .values
+                .first()
+            args.any { it.arguments.all { it is ConstantDescriptor.Null } } &&
+                    args.any { it.arguments.all { it is ArrayDescriptor && it.elements.values.all { it is ConstantDescriptor.Null } } } &&
+                    args.any { it.arguments.all { it is ArrayDescriptor && it.elements.values.all { it !is ConstantDescriptor.Null } } }
+        }
+    }
+
+    private fun <T> foldListTerm(list: ObjectDescriptor, initialValue: T, itemVisitor: (Descriptor, T) -> T): T {
+        require(list.klass.klass == "java/util/LinkedList")
+        val (firstName, nodeType) = list.fields.keys.find { (name) -> name == "first" }!!
+        var node: Descriptor = list.fields[firstName to nodeType]!!
+        var accumulate: T = initialValue
+        while (node is ObjectDescriptor) {
+            val itemKey = list.fields.keys.find { (name) -> name == "item" }!!
+            val item = list.fields[itemKey]!!
+            accumulate = itemVisitor(item, accumulate)
+            val nextKey = list.fields.keys.find { (name) -> name == "next" }!!
+            val next = list.fields[nextKey]!!
+            node = next
+        }
+        return accumulate
+    }
+
+    private fun <T> foldKexList(list: ObjectDescriptor, initialValue: T, itemVisitor: (Descriptor, T) -> T): T {
+        require(list.klass.klass == "kex/java/util/LinkedList")
+        val innerField = list.fields.keys.find { (name) -> name == "inner" }!!
+        val inner = list.fields[innerField]!!
+        require(inner is ObjectDescriptor)
+        val elementDataKey = list.fields.keys.find { (name) -> name == "elementData" }!!
+        val elementData = list.fields[elementDataKey]!!
+        require(elementData is ArrayDescriptor)
+        return (0 until elementData.length)
+            .fold(initialValue) { acc, idx -> itemVisitor(elementData.elements[idx]!!, acc) }
+    }
+
+    private fun traverseList(list: ObjectDescriptor, visitor: (Descriptor) -> Unit) {
+        val wrapper = { desc: Descriptor, _: Unit -> visitor(desc) }
+        when (list.klass.klass) {
+            "java/util/LinkedList" -> foldListTerm(list, Unit, wrapper)
+            "kex/java/util/LinkedList" -> foldKexList(list, Unit, wrapper)
+            else -> error("${list.klass.klass} is not a list class")
+        }
+    }
+
+    private val Descriptor.isList: Boolean
+        get() = this is ObjectDescriptor
+                && (this.klass.klass == "java/util/LinkedList" || this.klass.klass == "kex/java/util/LinkedList")
+    private val Descriptor.isNullableList: Boolean
+        get() = this.isList || this is ConstantDescriptor.Null
+
+    @Test
+    fun nonNullableListWithNonNullableElements() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithListWithoutNullsTest"])
+        val args = collectedArguments
+            .filter { (method) -> method.name == "withListWithoutNulls" }
+            .values
+            .first()
+        assertTrue { args.all { it.arguments.all { it.isList } && it.arguments.size == 1 } }
+        args
+            .map { it.arguments.filterIsInstance<ObjectDescriptor>().first() }
+            .forEach {
+                traverseList(it) { item: Descriptor ->
+                    assertTrue(item is ObjectDescriptor)
+                    val itemValueKey = item.fields.keys.find { (name) -> name == "value" }!!
+                    val itemValue = item[itemValueKey]!!
+                    assertTrue(itemValue !is ConstantDescriptor.Null)
+                    print("(item $itemValue) ")
+                }
+                println()
+            }
+    }
+
+
+    @Test
+    fun nonNullableListWithNullElements() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithListWithNullsTest"])
+        val args = collectedArguments
+            .filter { (method) -> method.name == "withListWithNulls" }
+            .values
+            .first()
+        assertTrue { args.all { it.arguments.all { it.isList } && it.arguments.size == 1 } }
+        var nullCount = 0
+        var notNullCount = 0
+        args
+            .map { it.arguments.filterIsInstance<ObjectDescriptor>().first() }
+            .forEach {
+                traverseList(it) { item: Descriptor ->
+                    if (item is ConstantDescriptor.Null) {
+                        nullCount++
+                        return@traverseList
+                    }
+                    assertTrue(item is ObjectDescriptor)
+                    val itemValueKey = item.fields.keys.find { (name) -> name == "value" }!!
+                    val itemValue = item[itemValueKey]!!
+                    if (itemValue is ConstantDescriptor.Null) {
+                        nullCount++
+                    } else {
+                        notNullCount++
+                    }
+                    print("(item $itemValue) ")
+                }
+                println()
+            }
+        assertTrue("There is no null element generated") { nullCount > 0 }
+        assertTrue("There is no not null element generated") { notNullCount > 0 }
+    }
+
+    @Test
+    fun nullableListWithNullableElements() {
+        val collectedArguments = runAndCollectArguments(cm[prefix + "WithNullableListWithNullsTest"])
+        val args = collectedArguments
+            .filter { (method) -> method.name == "withNullableListWithNulls" }
+            .values
+            .first()
+        assertTrue { args.all { it.arguments.all { it.isNullableList } && it.arguments.size == 1 } }
+        assertTrue { args.any { it.arguments.first().isList } && args.any { it.arguments.first().isNullableList } }
+        var nullCount = 0
+        var notNullCount = 0
+        args
+            .map { it.arguments.first() }
+            .filterIsInstance<ObjectDescriptor>()
+            .forEach {
+                traverseList(it) { item: Descriptor ->
+                    if (item is ConstantDescriptor.Null) {
+                        nullCount++
+                        return@traverseList
+                    }
+                    assertTrue(item is ObjectDescriptor)
+                    val itemValueKey = item.fields.keys.find { (name) -> name == "value" }!!
+                    val itemValue = item[itemValueKey]!!
+                    if (itemValue is ConstantDescriptor.Null) {
+                        nullCount++
+                    } else {
+                        notNullCount++
+                    }
+                    print("(item $itemValue) ")
+                }
+                println()
+            }
+        assertTrue("There is no null element generated") { nullCount > 0 }
+        assertTrue("There is no not null element generated") { notNullCount > 0 }
+    }
+
+
+    companion object {
+        private const val N_RUNS = 1
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithArrayWithNullsTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithArrayWithNullsTest.kt
@@ -1,0 +1,7 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithArrayWithNullsTest {
+    fun withArrayWithNulls(x: Array<Int?>) {
+        require(x.any { it != null })
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithArrayWithoutNullsTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithArrayWithoutNullsTest.kt
@@ -1,0 +1,7 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithArrayWithoutNullsTest {
+    fun withArrayWithoutNulls(x: Array<Int>) {
+        require(x.all { it != null && it != 30 })
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithListWithNullsTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithListWithNullsTest.kt
@@ -1,0 +1,16 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithListWithNullsTest {
+    fun withListWithNulls(x: List<Int?>): Int {
+        if (x.count {it != null} > 3) {
+            return 0
+        }
+        if (x.all { it == null} && x.size > 1) {
+            return 1
+        }
+        if (x.all {it != null} && x.size > 1) {
+            return 2
+        }
+        return 3
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithListWithoutNullsTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithListWithoutNullsTest.kt
@@ -1,0 +1,16 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithListWithoutNullsTest {
+    fun withListWithoutNulls(x: List<Int>): Int {
+        if (x.isEmpty()) {
+            error("empty")
+        }
+        if (x.first() == 10) {
+            return 1
+        }
+        if (x.size == 15) {
+            return 2
+        }
+        return 3
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableArrayTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableArrayTest.kt
@@ -1,0 +1,7 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithNullableArrayTest {
+    fun withNullableArray(x: Array<Int>?) {
+        require(x == null)
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableArrayWithNullableTypes.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableArrayWithNullableTypes.kt
@@ -1,0 +1,16 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithNullableArrayWithNullableTypes {
+    fun withNullableArrayWithNullableTypes(x: Array<Int?>?): Int {
+        if (x == null) {
+            return 1
+        }
+        if (x.any { it == null }) {
+            if (x.all { it == null }) {
+                return 2
+            }
+            return 3
+        }
+        return 4
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableListWithNullsTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableListWithNullsTest.kt
@@ -1,0 +1,16 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithNullableListWithNullsTest {
+    fun withNullableListWithNulls(x: List<Int?>?): Int {
+        if (x == null) {
+            return 1
+        }
+        if (x.any { it == null }) {
+            if (x.isNotEmpty()) {
+                return 4
+            }
+            return 2
+        }
+        return 3
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableTypesTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithNullableTypesTest.kt
@@ -1,0 +1,8 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithNullableTypesTest {
+    fun withNullableTypes(x: Int?): Double {
+        val y = x ?: 2024
+        return 1.0 / y
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithoutNullableTypesTest.kt
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/concolic/kotlinNullability/WithoutNullableTypesTest.kt
@@ -1,0 +1,10 @@
+package org.vorpal.research.kex.test.concolic.kotlinNullability
+
+class WithoutNullableTypesTest {
+    fun withoutNullableTypes(x: Int): Int {
+        if (x == 239) {
+            error("It's a very bad number")
+        }
+        return x + 566
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <kotlin.version>2.0.0</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <serialization.version>1.7.0-RC</serialization.version>
+        <kotlinx-metadata.version>0.9.0</kotlinx-metadata.version>
         <coroutines.version>1.8.1</coroutines.version>
         <collections.version>0.3.5</collections.version>
         <compiler-plugin.version>3.5.1</compiler-plugin.version>


### PR DESCRIPTION
The current implementation of the Kotlin Nullability markers (made via Kotlin's reflections) does not work as intended. This PR aims to address and fix this issue

- [ ] Made a test set for (non-)nullable types for Kotlin
- [ ] Make Primitive types work with nulls
- [ ] Make Array types work with nulls
- [ ] Make Object types work with nulls