### PR TITLE
Dumping JaCoCo Coverage into the JSON file

### DIFF
--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageInfo.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageInfo.kt
@@ -1,15 +1,18 @@
 package org.vorpal.research.kex.jacoco
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import org.vorpal.research.kthelper.assert.unreachable
 import org.vorpal.research.kthelper.logging.log
 
-
-interface CoverageInfo {
+@Serializable
+sealed interface CoverageInfo {
     val covered: Int
     val total: Int
     val ratio: Double
 }
 
+@Serializable
 enum class CoverageUnit(unit: String) {
     INSTRUCTION("instructions"),
     BRANCH("branches"),
@@ -33,6 +36,7 @@ enum class CoverageUnit(unit: String) {
     }
 }
 
+@Serializable
 enum class AnalysisUnit(unit: String) {
     METHOD("method"),
     CLASS("class"),
@@ -54,6 +58,8 @@ enum class AnalysisUnit(unit: String) {
     }
 }
 
+@Serializable
+@SerialName("genericCoverage")
 data class GenericCoverageInfo(
     override val covered: Int,
     override val total: Int,
@@ -74,7 +80,8 @@ data class GenericCoverageInfo(
     }
 }
 
-abstract class CommonCoverageInfo(
+@Serializable
+sealed class CommonCoverageInfo(
     val name: String,
     val level: AnalysisUnit,
     val instructionCoverage: CoverageInfo,
@@ -103,7 +110,8 @@ abstract class CommonCoverageInfo(
         return name.hashCode()
     }
 }
-
+@Serializable(with = MethodCoverageInfoSerializer::class)
+@SerialName("method")
 class MethodCoverageInfo(
     name: String,
     instructionCoverage: CoverageInfo,
@@ -119,6 +127,8 @@ class MethodCoverageInfo(
     complexityCoverage
 )
 
+@Serializable(with = ClassCoverageInfoSerializer::class)
+@SerialName("class")
 class ClassCoverageInfo(
     name: String,
     instructionCoverage: CoverageInfo,
@@ -146,6 +156,8 @@ class ClassCoverageInfo(
     }
 }
 
+@Serializable(with = PackageCoverageInfoSerializer::class)
+@SerialName("package")
 class PackageCoverageInfo(
     name: String,
     instructionCoverage: CoverageInfo,

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
@@ -90,7 +90,7 @@ open class CoverageReporter(
     }.also {
         deleteOnExit(it)
     }
-    val allTestClasses: Set<Path> by lazy { Files.walk(compileDir).filter { it.isClass }.toList().toSet() }
+    val allTestClasses: Set<Path> by lazy { Files.walk(compileDir).filter { it.isClass }.collect(Collectors.toSet()) }
     protected val compileDir = kexConfig.compiledCodeDirectory
     protected lateinit var coverageContext: CoverageContext
     protected lateinit var executionData: Map<Path, ExecutionDataStore>
@@ -154,7 +154,7 @@ open class CoverageReporter(
         is PackageLevel -> Files.walk(jacocoInstrumentedDir)
             .filter { it.isClass }
             .filter { analysisLevel.pkg.isParent(it.fullyQualifiedName(jacocoInstrumentedDir).asmString) }
-            .toList()
+            .collect(Collectors.toList())
 
         is ClassLevel -> {
             val additionalValues = kexConfig

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
@@ -2,6 +2,8 @@
 
 package org.vorpal.research.kex.jacoco
 
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jacoco.core.analysis.Analyzer
 import org.jacoco.core.analysis.CoverageBuilder
 import org.jacoco.core.analysis.ICounter
@@ -44,12 +46,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.*
-import kotlin.io.path.inputStream
-import kotlin.io.path.name
-import kotlin.io.path.readBytes
-import kotlin.io.path.relativeTo
-import kotlin.io.path.writeBytes
-import kotlin.streams.toList
+import kotlin.io.path.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -394,6 +391,8 @@ fun reportCoverage(
 
             else -> coverageReporter.computeCoverage(analysisLevel, testClasses)
         }
+        kexConfig.getPathValue("kex", "coverageJsonLocation")
+            ?.writeText(Json.encodeToString(coverageInfo))
 
         log.info(
             coverageInfo.print(kexConfig.getBooleanValue("kex", "printDetailedCoverage", false))

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/Serializers.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/Serializers.kt
@@ -1,0 +1,153 @@
+package org.vorpal.research.kex.jacoco
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * A surrogate class used to simplify the code of the [SurrogateCoverageInfo]
+ * by providing basic functionality of the decoding/encoding of the [CommonCoverageInfo]. The trick is found in
+ * [kotlinx serialization guide](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#composite-serializer-via-surrogate).
+ *
+ *
+ * The abstract class cannot be used in the first way to provide the serializer to abstract class
+ */
+@Serializable
+private sealed class SurrogateCoverageInfo {
+    abstract val name: String
+    abstract val level: AnalysisUnit
+    abstract val instructionCoverage: CoverageInfo
+    abstract val branchCoverage: CoverageInfo
+    abstract val linesCoverage: CoverageInfo
+    abstract val complexityCoverage: CoverageInfo
+}
+
+@Serializable
+@SerialName("method")
+private data class SurrogateMethodCoverageInfo(
+    override val name: String,
+    override val level: AnalysisUnit,
+    override val instructionCoverage: CoverageInfo,
+    override val branchCoverage: CoverageInfo,
+    override val linesCoverage: CoverageInfo,
+    override val complexityCoverage: CoverageInfo
+) : SurrogateCoverageInfo() {
+    val value: MethodCoverageInfo
+        get() = MethodCoverageInfo(name, instructionCoverage, branchCoverage, linesCoverage, complexityCoverage)
+
+    companion object {
+        fun fromValue(value: MethodCoverageInfo) = SurrogateMethodCoverageInfo(
+            value.name,
+            value.level,
+            value.instructionCoverage,
+            value.branchCoverage,
+            value.linesCoverage,
+            value.complexityCoverage,
+        )
+    }
+}
+
+@Serializable
+@SerialName("class")
+private data class SurrogateClassCoverageInfo(
+    override val name: String,
+    override val level: AnalysisUnit,
+    override val instructionCoverage: CoverageInfo,
+    override val branchCoverage: CoverageInfo,
+    override val linesCoverage: CoverageInfo,
+    override val complexityCoverage: CoverageInfo,
+    val methods: List<SurrogateMethodCoverageInfo>
+) : SurrogateCoverageInfo() {
+    val value: ClassCoverageInfo
+        get() {
+            val result = ClassCoverageInfo(name, instructionCoverage, branchCoverage, linesCoverage, complexityCoverage)
+            result.methods.addAll(methods.map { it.value })
+            return result
+        }
+
+    companion object {
+        fun fromValue(value: ClassCoverageInfo) = SurrogateClassCoverageInfo(
+            value.name,
+            value.level,
+            value.instructionCoverage,
+            value.branchCoverage,
+            value.linesCoverage,
+            value.complexityCoverage,
+            value.methods.map { SurrogateMethodCoverageInfo.fromValue(it) }
+        )
+    }
+}
+
+@Serializable
+@SerialName("package")
+private data class SurrogatePackageCoverageInfo(
+    override val name: String,
+    override val level: AnalysisUnit,
+    override val instructionCoverage: CoverageInfo,
+    override val branchCoverage: CoverageInfo,
+    override val linesCoverage: CoverageInfo,
+    override val complexityCoverage: CoverageInfo,
+    val classes: List<SurrogateClassCoverageInfo>,
+) : SurrogateCoverageInfo() {
+    val value: PackageCoverageInfo
+        get() {
+            val result =
+                PackageCoverageInfo(name, instructionCoverage, branchCoverage, linesCoverage, complexityCoverage)
+            result.classes.addAll(classes.map { it.value })
+            return result
+        }
+
+    companion object {
+        fun fromValue(value: PackageCoverageInfo) = SurrogatePackageCoverageInfo(
+            value.name,
+            value.level,
+            value.instructionCoverage,
+            value.branchCoverage,
+            value.linesCoverage,
+            value.complexityCoverage,
+            value.classes.map { SurrogateClassCoverageInfo.fromValue(it) }
+        )
+    }
+}
+
+object MethodCoverageInfoSerializer : KSerializer<MethodCoverageInfo> {
+    override val descriptor: SerialDescriptor = SurrogateMethodCoverageInfo.serializer().descriptor
+    override fun serialize(encoder: Encoder, value: MethodCoverageInfo) {
+        val surrogate = SurrogateMethodCoverageInfo.fromValue(value)
+        encoder.encodeSerializableValue(SurrogateMethodCoverageInfo.serializer(), surrogate)
+    }
+
+    override fun deserialize(decoder: Decoder): MethodCoverageInfo {
+        val surrogate = decoder.decodeSerializableValue(SurrogateMethodCoverageInfo.serializer())
+        return surrogate.value
+    }
+}
+
+object ClassCoverageInfoSerializer : KSerializer<ClassCoverageInfo> {
+    override val descriptor: SerialDescriptor = SurrogateClassCoverageInfo.serializer().descriptor
+    override fun serialize(encoder: Encoder, value: ClassCoverageInfo) {
+        val surrogate = SurrogateClassCoverageInfo.fromValue(value)
+        encoder.encodeSerializableValue(SurrogateClassCoverageInfo.serializer(), surrogate)
+    }
+    override fun deserialize(decoder: Decoder): ClassCoverageInfo {
+        val surrogate = decoder.decodeSerializableValue(SurrogateClassCoverageInfo.serializer())
+        return surrogate.value
+    }
+}
+
+object PackageCoverageInfoSerializer : KSerializer<PackageCoverageInfo> {
+    override val descriptor: SerialDescriptor = SurrogatePackageCoverageInfo.serializer().descriptor
+    override fun serialize(encoder: Encoder, value: PackageCoverageInfo) {
+        val surrogate = SurrogatePackageCoverageInfo.fromValue(value)
+        encoder.encodeSerializableValue(SurrogatePackageCoverageInfo.serializer(), surrogate)
+    }
+
+    override fun deserialize(decoder: Decoder): PackageCoverageInfo {
+        val surrogate = decoder.decodeSerializableValue(SurrogatePackageCoverageInfo.serializer())
+        return surrogate.value
+    }
+}
+

--- a/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/ConcolicTest.kt
+++ b/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/ConcolicTest.kt
@@ -34,8 +34,8 @@ abstract class ConcolicTest(testDirectoryName: String) : KexRunnerTest(testDirec
             }
 
             val coverage = CoverageReporter(klass.cm, listOf(jar)).computeCoverage(ClassLevel(klass))
-            log.debug(coverage.print(true))
-            assertEquals(expectedCoverage, coverage.instructionCoverage.ratio, eps)
+            log.debug(coverage.first().print(true))
+            assertEquals(expectedCoverage, coverage.first().instructionCoverage.ratio, eps)
         }
     }
 }

--- a/kex-runner/src/test/kotlin/org/vorpal/research/kex/symbolic/SymbolicTest.kt
+++ b/kex-runner/src/test/kotlin/org/vorpal/research/kex/symbolic/SymbolicTest.kt
@@ -33,7 +33,7 @@ abstract class SymbolicTest(
         }
 
         val coverage = CoverageReporter(klass.cm, listOf(jar)).computeCoverage(ClassLevel(klass))
-        log.debug(coverage.print(true))
-        assertEquals(expectedCoverage, coverage.instructionCoverage.ratio, eps)
+        log.debug(coverage.first().print(true))
+        assertEquals(expectedCoverage, coverage.first().instructionCoverage.ratio, eps)
     }
 }


### PR DESCRIPTION
## Changes
Added a `@Serializable` annotation to the CoverageInfo classes as well as the Serializers for them. Additionally, I've changed the signature of the `collectCoverage` for collecting more coverage

I added two new flags:
*  `coverageJsonLocation` — a path for a result JSON file that contains a set of all covered objects
* `collectWholeCoverage` — a boolean flag to collect the coverage of all classes (except the kotlin/kex/Java stdlib)

## Threats
The `collectWholeCoverage` for now only works for classes, the filters for stdlib are written very sketchily and, I suppose, require a full refactor
