### PR TITLE
Coverage and minimization bug fixes

### DIFF
--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/concolic/InstructionConcolicChecker.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/concolic/InstructionConcolicChecker.kt
@@ -38,7 +38,9 @@ import org.vorpal.research.kex.trace.symbolic.SymbolicState
 import org.vorpal.research.kex.trace.symbolic.persistentSymbolicState
 import org.vorpal.research.kex.trace.symbolic.protocol.ExecutionCompletedResult
 import org.vorpal.research.kex.trace.symbolic.protocol.ExecutionResult
-import org.vorpal.research.kex.util.*
+import org.vorpal.research.kex.util.compiledCodeDirectory
+import org.vorpal.research.kex.util.newFixedThreadPoolContextWithMDC
+import org.vorpal.research.kex.util.testcaseDirectory
 import org.vorpal.research.kfg.ClassManager
 import org.vorpal.research.kfg.ir.Method
 import org.vorpal.research.kthelper.assert.unreachable

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/concolic/InstructionConcolicChecker.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/concolic/InstructionConcolicChecker.kt
@@ -38,7 +38,7 @@ import org.vorpal.research.kex.trace.symbolic.SymbolicState
 import org.vorpal.research.kex.trace.symbolic.persistentSymbolicState
 import org.vorpal.research.kex.trace.symbolic.protocol.ExecutionCompletedResult
 import org.vorpal.research.kex.trace.symbolic.protocol.ExecutionResult
-import org.vorpal.research.kex.util.newFixedThreadPoolContextWithMDC
+import org.vorpal.research.kex.util.*
 import org.vorpal.research.kfg.ClassManager
 import org.vorpal.research.kfg.ir.Method
 import org.vorpal.research.kthelper.assert.unreachable
@@ -49,6 +49,7 @@ import org.vorpal.research.kthelper.tryOrNull
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.io.path.deleteIfExists
+import kotlin.io.path.relativeTo
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
@@ -171,8 +172,12 @@ class InstructionConcolicChecker(
                         testWithAssertions = testWithAssertionsGenerator.emit()
                         compilerHelper.compileFile(testWithAssertions)
 
-                        // delete the original test in the end, only if there were no errors with assertions
+                        // delete the original test in the end (.java file), only if there were no errors with assertions
                         testFile.deleteIfExists()
+                        // deleting .class file
+                        val classFqnPath =
+                            testFile.relativeTo(kexConfig.testcaseDirectory).toString().replaceAfterLast('.', "class")
+                        kexConfig.compiledCodeDirectory.resolve(classFqnPath).deleteIfExists()
                     }
                 } catch (e: Throwable) {
                     testWithAssertions?.deleteIfExists()

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
@@ -378,6 +378,7 @@ fun reportCoverage(
     val coverageReporter: CoverageReporter
     val testClasses: Set<Path>
     if (kexConfig.getBooleanValue("kex", "minimizeTestSuite", false)) {
+
         coverageReporter = TestwiseCoverageReporter(cm, containers)
         val testCoverage = coverageReporter.computeTestwiseCoverageInfo(analysisLevel)
         testClasses = GreedyTestReductionImpl().minimize(testCoverage)

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/CoverageReporter.kt
@@ -378,7 +378,6 @@ fun reportCoverage(
     val coverageReporter: CoverageReporter
     val testClasses: Set<Path>
     if (kexConfig.getBooleanValue("kex", "minimizeTestSuite", false)) {
-
         coverageReporter = TestwiseCoverageReporter(cm, containers)
         val testCoverage = coverageReporter.computeTestwiseCoverageInfo(analysisLevel)
         testClasses = GreedyTestReductionImpl().minimize(testCoverage)

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
@@ -1,6 +1,5 @@
 package org.vorpal.research.kex.jacoco.minimization
 
-import com.jetbrains.rd.util.first
 import org.vorpal.research.kex.config.kexConfig
 import java.nio.file.Path
 
@@ -59,7 +58,4 @@ class GreedyTestReductionImpl : TestSuiteMinimizer {
 
         return importantTests
     }
-   private fun String.getPath(): Path {
-        return tests.map { it.key }.first { it.toString().contains(this)}
-   }
 }

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
@@ -50,8 +50,6 @@ class GreedyTestReductionImpl : TestSuiteMinimizer {
             maxTest.reqs.forEach { requirements[it]!!.visit(tests) }
             importantTests.add(maxTestPath)
         }
-        // TODO don't use fragile string comparisons
-        importantTests.addAll(listOf("EqualityUtils.class", "ReflectionUtils.class").map {it.getPath()})
 
         val allTests = tests.keys.toList()
         val reducedTests = allTests.subtract(importantTests.toSet()).toSet()

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
@@ -1,5 +1,6 @@
 package org.vorpal.research.kex.jacoco.minimization
 
+import com.jetbrains.rd.util.first
 import org.vorpal.research.kex.config.kexConfig
 import java.nio.file.Path
 
@@ -49,6 +50,8 @@ class GreedyTestReductionImpl : TestSuiteMinimizer {
             maxTest.reqs.forEach { requirements[it]!!.visit(tests) }
             importantTests.add(maxTestPath)
         }
+        // TODO don't use fragile string comparisons
+        importantTests.addAll(listOf("EqualityUtils.class", "ReflectionUtils.class").map {it.getPath()})
 
         val allTests = tests.keys.toList()
         val reducedTests = allTests.subtract(importantTests.toSet()).toSet()
@@ -58,4 +61,7 @@ class GreedyTestReductionImpl : TestSuiteMinimizer {
 
         return importantTests
     }
+   private fun String.getPath(): Path {
+        return tests.map { it.key }.first { it.toString().contains(this)}
+   }
 }

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/jacoco/minimization/GreedyTestReductionImpl.kt
@@ -1,5 +1,6 @@
 package org.vorpal.research.kex.jacoco.minimization
 
+import org.vorpal.research.kex.config.kexConfig
 import java.nio.file.Path
 
 private class Test(
@@ -39,7 +40,8 @@ class GreedyTestReductionImpl : TestSuiteMinimizer {
 
         var satisfiedReq = 0
         val importantTests = mutableSetOf<Path>()
-        while (satisfiedReq < requestSet.size) {
+        val maxTests = kexConfig.getIntValue("testGen", "maxTests", Integer.MAX_VALUE)
+        while (satisfiedReq < requestSet.size && importantTests.size < maxTests) {
             val (maxTestPath, maxTest) = tests.maxByOrNull { it.value.power } ?: break
             if (maxTest.power == 0) break
 

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/reanimator/codegen/javagen/EqualityUtilsPrinter.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/reanimator/codegen/javagen/EqualityUtilsPrinter.kt
@@ -28,7 +28,7 @@ class EqualityUtilsPrinter(
             val testDirectory = kexConfig.testcaseDirectory
             return equalityUtilsInstances.getOrPut(testDirectory to packageName) {
                 val utils = EqualityUtilsPrinter(packageName)
-                val targetFileName = "EqualityUtils.java"
+                val targetFileName = "$EQUALITY_UTILS_CLASS.java"
                 val targetFile = testDirectory
                     .resolve(packageName.asmString)
                     .resolve(targetFileName)
@@ -39,7 +39,11 @@ class EqualityUtilsPrinter(
             }
         }
 
-        fun equalityUtilsClasses(): Set<Path> = equalityUtilsInstances.mapTo(mutableSetOf()) { it.key.first }
+        fun equalityUtilsClasses(): Set<Path> = equalityUtilsInstances.mapTo(mutableSetOf()) {
+            it.key.first.resolve(it.key.second.asmString).resolve(
+                "$EQUALITY_UTILS_CLASS.java"
+            )
+        }
 
         @Suppress("unused")
         fun invalidateAll() {

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/reanimator/codegen/javagen/ReflectionUtilsPrinter.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/reanimator/codegen/javagen/ReflectionUtilsPrinter.kt
@@ -38,7 +38,7 @@ class ReflectionUtilsPrinter(
             val testDirectory = kexConfig.testcaseDirectory
             return reflectionUtilsInstances.getOrPut(testDirectory to packageName) {
                 val utils = ReflectionUtilsPrinter(packageName)
-                val targetFileName = "ReflectionUtils.java"
+                val targetFileName = "$REFLECTION_UTILS_CLASS.java"
                 val targetFile = testDirectory
                     .resolve(packageName.asmString)
                     .resolve(targetFileName)
@@ -49,7 +49,11 @@ class ReflectionUtilsPrinter(
             }
         }
 
-        fun reflectionUtilsClasses(): Set<Path> = reflectionUtilsInstances.mapTo(mutableSetOf()) { it.key.first }
+        fun reflectionUtilsClasses(): Set<Path> = reflectionUtilsInstances.mapTo(mutableSetOf()) {
+            it.key.first.resolve(it.key.second.asmString).resolve(
+                "$REFLECTION_UTILS_CLASS.java"
+            )
+        }
 
         @Suppress("unused")
         fun invalidateAll() {

--- a/kex.ini
+++ b/kex.ini
@@ -28,6 +28,7 @@ generateAssertions = true
 logJUnit = true
 testTimeout = 10
 surroundInTryCatch = false
+maxTests = 5
 
 ignoreStatic = class java.lang.System
 ignoreStatic = class kex.java.util.Arrays

--- a/kex.ini
+++ b/kex.ini
@@ -29,7 +29,6 @@ generateAssertions = true
 logJUnit = true
 testTimeout = 10
 surroundInTryCatch = false
-maxTests = 50
 
 ignoreStatic = class java.lang.System
 ignoreStatic = class kex.java.util.Arrays

--- a/kex.ini
+++ b/kex.ini
@@ -1,5 +1,6 @@
 ;suppress inspection "DuplicateKeyInSection" for whole file
 [kex]
+minimizeTestSuite = false
 runtimeDepsPath = runtime-deps/
 libPath = lib/
 rtVersion = 1.8
@@ -28,7 +29,6 @@ generateAssertions = true
 logJUnit = true
 testTimeout = 10
 surroundInTryCatch = false
-maxTests = 5
 
 ignoreStatic = class java.lang.System
 ignoreStatic = class kex.java.util.Arrays

--- a/kex.ini
+++ b/kex.ini
@@ -29,6 +29,7 @@ generateAssertions = true
 logJUnit = true
 testTimeout = 10
 surroundInTryCatch = false
+maxTests = 50
 
 ignoreStatic = class java.lang.System
 ignoreStatic = class kex.java.util.Arrays


### PR DESCRIPTION
Kex generates test code (.java files) in two stages: first without assertions and then with assertions. The old (without assertion) .java files are deleted but the corresponding .class files were not deleted. This caused incorrect (somehow non-deterministic) behaviour with coverage calculations of `jacoco`  which are further used in testsuite minimization.

# Summary
- remove the duplicate .class files
- do not remove helper classes `EqualityUtils.java` and `ReflectionUtils.java`
- Introduce a maxTests config variable to limit number of tests displayed. Highest coverage achieving unit tests are prioritised