### PR TITLE
Disable null values

### DIFF
--- a/kex-core/src/main/kotlin/org/vorpal/research/kex/parameters/Parameters.kt
+++ b/kex-core/src/main/kotlin/org/vorpal/research/kex/parameters/Parameters.kt
@@ -6,8 +6,11 @@ import org.vorpal.research.kex.config.kexConfig
 import org.vorpal.research.kex.descriptor.*
 import org.vorpal.research.kex.ktype.KexClass
 import org.vorpal.research.kex.ktype.KexRtManager.rtMapped
+import org.vorpal.research.kex.ktype.KexType
+import org.vorpal.research.kex.ktype.kexType
 import org.vorpal.research.kex.util.KfgTargetFilter
 import org.vorpal.research.kfg.ClassManager
+import org.vorpal.research.kfg.ir.Method
 import kotlin.random.Random
 
 @Serializable
@@ -91,4 +94,43 @@ fun Parameters<Descriptor>.filterIgnoredStatic(): Parameters<Descriptor> {
             }
         }
     return Parameters(instance, arguments, filteredStatics)
+}
+
+fun Parameters<Descriptor>.replaceNullsWithDefaultValues(method: Method): Parameters<Descriptor> {
+    val parametersWithoutNulls = arguments
+        .zip(method.argTypes)
+        .map { (descriptor, type) -> transformExistingDescriptor(descriptor, type.kexType) }
+    return Parameters(instance, parametersWithoutNulls, statics)
+}
+
+private fun transformExistingDescriptor(descriptor: Descriptor, type: KexType): Descriptor {
+    return when (descriptor) {
+        // TODO: Should object here be initialized properly?
+        is ConstantDescriptor.Null -> descriptor { default(type, nullable = false) }
+        is ConstantDescriptor -> descriptor
+        is ArrayDescriptor -> ArrayDescriptor(descriptor.elementType, descriptor.length)
+            .apply {
+                descriptor.elements.forEach { (index, value) ->
+                    this[index] = transformExistingDescriptor(value, descriptor.elementType)
+                }
+            }
+        is ObjectDescriptor -> ObjectDescriptor(descriptor.klass).apply {
+            descriptor.fields.forEach { (key, desc) ->
+                val (name, fieldType) = key
+                set(name to fieldType, transformExistingDescriptor(desc, fieldType))
+            }
+        }
+        is ClassDescriptor -> ClassDescriptor(descriptor.klass).apply {
+            descriptor.fields.forEach { (key, desc) ->
+                val (name, fieldType) = key
+                set(name to fieldType, transformExistingDescriptor(desc, fieldType))
+            }
+        }
+        is MockDescriptor -> MockDescriptor(descriptor.klass).apply {
+            descriptor.fields.forEach { (key, desc) ->
+                val (name, fieldType) = key
+                set(name to fieldType, transformExistingDescriptor(desc, fieldType))
+            }
+        }
+    }
 }

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/util/extensions.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/util/extensions.kt
@@ -78,7 +78,7 @@ suspend fun Method.checkAsync(
             .concreteParameters(ctx.cm, ctx.accessLevel, ctx.random)
             .let {
                 if (!kexConfig.getBooleanValue("kex", "generateNulls", true))
-                    it.replaceNullsWithDefaultValues(this)
+                    it.replaceNullsWithDefaultValues(this, ctx.cm)
                 else
                     it
             }

--- a/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/util/extensions.kt
+++ b/kex-runner/src/main/kotlin/org/vorpal/research/kex/asm/analysis/util/extensions.kt
@@ -14,10 +14,7 @@ import org.vorpal.research.kex.ktype.KexRtManager.rtMapped
 import org.vorpal.research.kex.ktype.kexType
 import org.vorpal.research.kex.mocking.performMocking
 import org.vorpal.research.kex.mocking.withoutMocksOrNull
-import org.vorpal.research.kex.parameters.Parameters
-import org.vorpal.research.kex.parameters.concreteParameters
-import org.vorpal.research.kex.parameters.filterIgnoredStatic
-import org.vorpal.research.kex.parameters.filterStaticFinals
+import org.vorpal.research.kex.parameters.*
 import org.vorpal.research.kex.smt.AsyncChecker
 import org.vorpal.research.kex.smt.AsyncIncrementalChecker
 import org.vorpal.research.kex.smt.Result
@@ -79,6 +76,12 @@ suspend fun Method.checkAsync(
             .parameters
             .filterStaticFinals(ctx.cm)
             .concreteParameters(ctx.cm, ctx.accessLevel, ctx.random)
+            .let {
+                if (!kexConfig.getBooleanValue("kex", "generateNulls", true))
+                    it.replaceNullsWithDefaultValues(this)
+                else
+                    it
+            }
             .also { log.debug { "Generated params:\n$it" } }
             .filterIgnoredStatic()
     } catch (e: Throwable) {

--- a/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/DisableNullsTest.kt
+++ b/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/DisableNullsTest.kt
@@ -17,18 +17,18 @@ class DisableNullsTest : ConcolicTest("do-not-generate-nulls") {
     }
     @Test
     fun boxedTypeWithoutNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedTypeNulls"], 7.0 / 9.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedTypeNulls"], 7.0 / 9.0, eps = 0.1)
     }
     @Test
     fun primitiveArrayWithoutNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls"], 7.0 / 9.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls"], 7.0 / 9.0, eps = 0.1)
     }
     @Test
     fun boxedArrayWithoutNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedArrayNulls"], 20.0 / 24.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedArrayNulls"], 20.0 / 24.0, eps = 0.1)
     }
     @Test
     fun listWithoutNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/ListNulls"], 20.0 / 24.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/ListNulls"], 20.0 / 24.0, eps = 0.1)
     }
 }

--- a/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/DisableNullsTest.kt
+++ b/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/DisableNullsTest.kt
@@ -1,0 +1,34 @@
+package org.vorpal.research.kex.concolic
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import org.junit.Test
+import org.vorpal.research.kex.config.RuntimeConfig
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+@ExperimentalSerializationApi
+@InternalSerializationApi
+@DelicateCoroutinesApi
+class DisableNullsTest : ConcolicTest("do-not-generate-nulls") {
+    init {
+        RuntimeConfig.setValue("kex", "generateNulls", false)
+    }
+    @Test
+    fun boxedTypeWithoutNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedTypeNulls"], 7.0 / 9.0)
+    }
+    @Test
+    fun primitiveArrayWithoutNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls"], 7.0 / 9.0)
+    }
+    @Test
+    fun boxedArrayWithoutNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedArrayNulls"], 20.0 / 24.0)
+    }
+    @Test
+    fun listWithoutNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/ListNulls"], 20.0 / 24.0)
+    }
+}

--- a/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/GenerateNullsTest.kt
+++ b/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/GenerateNullsTest.kt
@@ -17,18 +17,18 @@ class GenerateNullsTest : ConcolicTest("generate-nulls") {
     }
     @Test
     fun boxedTypeWithNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedTypeNulls"], 1.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedTypeNulls"], 1.0, eps = 0.1)
     }
     @Test
     fun primitiveArrayWithNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls"], 1.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls"], 1.0, eps = 0.1)
     }
     @Test
     fun boxedArrayWithNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedArrayNulls"], 1.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedArrayNulls"], 1.0, eps = 0.1)
     }
     @Test
     fun listWithNullsTest() {
-        assertCoverage(cm["org/vorpal/research/kex/test/nullability/ListNulls"], 1.0)
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/ListNulls"], 1.0, eps = 0.1)
     }
 }

--- a/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/GenerateNullsTest.kt
+++ b/kex-runner/src/test/kotlin/org/vorpal/research/kex/concolic/GenerateNullsTest.kt
@@ -1,0 +1,34 @@
+package org.vorpal.research.kex.concolic
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import org.junit.Test
+import org.vorpal.research.kex.config.RuntimeConfig
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+@ExperimentalSerializationApi
+@InternalSerializationApi
+@DelicateCoroutinesApi
+class GenerateNullsTest : ConcolicTest("generate-nulls") {
+    init {
+        RuntimeConfig.setValue("kex", "generateNulls", true)
+    }
+    @Test
+    fun boxedTypeWithNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedTypeNulls"], 1.0)
+    }
+    @Test
+    fun primitiveArrayWithNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls"], 1.0)
+    }
+    @Test
+    fun boxedArrayWithNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/BoxedArrayNulls"], 1.0)
+    }
+    @Test
+    fun listWithNullsTest() {
+        assertCoverage(cm["org/vorpal/research/kex/test/nullability/ListNulls"], 1.0)
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/BoxedArrayNulls.java
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/BoxedArrayNulls.java
@@ -1,0 +1,15 @@
+package org.vorpal.research.kex.test.nullability;
+
+public class BoxedArrayNulls {
+    int function(Integer[] x) {
+        if (x == null) {
+            return -1;
+        }
+        for (int i = 0; i < x.length; i++) {
+            if (x[i] == null) {
+                return i;
+            }
+        }
+        return x.length;
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/BoxedTypeNulls.java
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/BoxedTypeNulls.java
@@ -1,0 +1,10 @@
+package org.vorpal.research.kex.test.nullability;
+
+public class BoxedTypeNulls {
+    int function(Integer x) {
+        if (x == null) {
+            return 1;
+        }
+        return 2;
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/ListNulls.java
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/ListNulls.java
@@ -1,0 +1,17 @@
+package org.vorpal.research.kex.test.nullability;
+
+import java.util.List;
+
+public class ListNulls {
+    int function(List<Integer> x) {
+        if (x == null) {
+            return -1;
+        }
+        for (int i = 0; i < x.size(); i++) {
+            if (x.get(i) == null) {
+                return i;
+            }
+        }
+        return x.size();
+    }
+}

--- a/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls.java
+++ b/kex-test/src/main/kotlin/org/vorpal/research/kex/test/nullability/PrimitiveArrayNulls.java
@@ -1,0 +1,10 @@
+package org.vorpal.research.kex.test.nullability;
+
+public class PrimitiveArrayNulls {
+    int function(int[] x) {
+        if (x == null) {
+            return -1;
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
This pull request added a new flag: `kex.generateNullValues` with the default value of true.

If the flag is set to false, it will replace all null values immediately after it's obtained from SMT solver to the default value.

For the classes the method sets all the fields that are defined in their default values as well.
